### PR TITLE
Release 1.7.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 1.7.2
+
+Release notes: https://github.com/asacolips-projects/dungeonworld/releases/tag/1.7.2
+
+- Fixed various bugs related to enriched text fields.
+
 # 1.7.1
 
 ## Bug Fixes

--- a/README.md
+++ b/README.md
@@ -1,29 +1,60 @@
-# Install
+![Foundry v11.315](https://img.shields.io/badge/Foundry-v11.315-green)
 
-1. Go to the setup page and choose **Game Systems**.
-2. Click the **Install System** button, and find the system in the installer list or paste in this manifest link:
-    * Foundry 0.7.x: [https://gitlab.com/asacolips-projects/foundry-mods/dungeonworld/-/jobs/artifacts/master/raw/system.json?job=build-prod](https://gitlab.com/asacolips-projects/foundry-mods/dungeonworld/-/jobs/artifacts/master/raw/system.json?job=build-prod)
-3. Create a Game World using the Dungeon World system.
+## Install
 
-Compatible with FoundryVTT 0.6.x and 0.7.x.
+You can find Dungeon World in the Foundry VTT package listing.
 
-# Description
+To install manually, use this manifest link:
 
-Build campaigns in the Dungeon World RPG using Foundry VTT!
+https://asacolips-artifacts.s3.amazonaws.com/dungeonworld/latest/system.json
 
-# Contributing
+## Features
+
+- Character sheets for characters and monsters/npcs
+- Rollable ability scores, moves, and spells
+- Various roll types for moves, including prompts to choose what ability score to use
+- Areas to track forward, hold, ongoing, and one custom resource
+- Max health and load calculations (can be overridden)
+- Weight tracking
+- Character builder for easily creating and leveling up characters
+- Macrobar support for moves and spells
+- Compendiums for the core book's basic moves, class moves, and class spells
+- Ability to override included moves or classes, and to create custom moves, classes, and tags
+
+## Languages
+
+- English (default)
+- French
+- German
+- Spanish
+
+## Screenshots
+
+### Character Sheet
+![character sheet](https://mattsmithin.nyc3.digitaloceanspaces.com/assets/dw-0.3.0.png)
+
+### Character Builder
+![character builder](https://mattsmithin.nyc3.digitaloceanspaces.com/assets/dw-0.3.0-character-builder.png)
+
+### Level Up
+![level up](https://mattsmithin.nyc3.digitaloceanspaces.com/assets/dw-0.3.0-level-up.png)
+
+### Combat Tracker
+![combat tracker](https://gitlab.com/asacolips-projects/foundry-mods/dungeonworld/uploads/e3ff32b9c9e94c0dd57aeffa7e679e28/image.png)
+
+## Contributing
 
 This project is accepting issue reports and code merge requests! See the [CONTRIBUTING.MD](https://gitlab.com/asacolips-projects/foundry-mods/dungeonworld/-/blob/master/CONTRIBUTING.md) page for details.
 
-## Translations
+### Translations
 
 If you would like to contribute translations directly to the system, they're written using YAML and are under `src/yaml/lang`, and the repo includes build tools to convert them back into JSON. If you prefer writing in JSON, you can convert from JSON to YAML at https://www.json2yaml.com/
 
-## Building the system from source
+### Building the system from source
 
 To build the system from source, you'll need to have node 12 or higher installed so that you can use npm and gulp. Changes made to either the `dist` directory or `system.json` in the root of this repo will be lost when building; you should instead edit the source files within `src`. Of particular note is that the system.json, template.json, and lang files are all originally written in Yaml format for an easier to read and work with syntax. You should make your changes there and build their json equivalents with npm.
 
-## Running builds
+### Running builds
 
 To make a new dist build, run the following commands:
 
@@ -36,29 +67,15 @@ Once the build has been completed, you can either copy/paste the dist directory'
 
 In addition, there are other commands for individual tasks, such as `npm run yaml` for compiling the yaml > json assets only.
 
-## CSS
+### CSS
 
 This project uses SCSS for generating its CSS. This can also be compiled via `npm run build`.
 
-# Screenshots
-
-## Character Sheet
-![character sheet](https://mattsmithin.nyc3.digitaloceanspaces.com/assets/dw-0.3.0.png)
-
-## Character Builder
-![character builder](https://mattsmithin.nyc3.digitaloceanspaces.com/assets/dw-0.3.0-character-builder.png)
-
-## Level Up
-![level up](https://mattsmithin.nyc3.digitaloceanspaces.com/assets/dw-0.3.0-level-up.png)
-
-## Combat Tracker
-![combat tracker](https://gitlab.com/asacolips-projects/foundry-mods/dungeonworld/uploads/e3ff32b9c9e94c0dd57aeffa7e679e28/image.png)
-
-# Hack Modules
+## Hack Modules
 
 - [Homebrew World](https://gitlab.com/mangofeet/homebrew-world-module)
 
-# Licensing
+## Licensing
 
 All HTML, CSS, and JS is licensed under the [MIT license](https://gitlab.com/asacolips-projects/foundry-mods/dungeonworld/-/raw/master/LICENSE.txt).
 

--- a/release-notes/1.7.2.md
+++ b/release-notes/1.7.2.md
@@ -1,0 +1,17 @@
+## Downloads
+
+Manifest URL: https://asacolips-artifacts.s3.amazonaws.com/dungeonworld/1.7.2/system.json
+
+## Compatible Foundry Versions
+![Foundry v11.315](https://img.shields.io/badge/Foundry-v11.315-green)
+
+## Changes
+
+- Updated compendium build script to use the fvtt cli. This allows us to compile directly to LevelDB for Foundry v11, rather than the older NeDB setup that had to be converted when a world was loaded.
+- We moved to Github! This shouldn't affect your games directly, but the code repository is now on Github rather than Gitlab. All issues have been migrated to the new repository, and the main reason for the migration was the increased quota of build minutes on Github allowing me to integrate more tests into our pull request and release processes.
+
+## Bug Fixes
+
+- Fixed several bugs related to text editors and displaying their content as enriched. There's still some work left to do on this related to the level up dialog and compendium entries in journals, but character and item sheets should now all display links and rolls properly!
+
+

--- a/src/yaml/system.yml
+++ b/src/yaml/system.yml
@@ -7,7 +7,7 @@ compatibleCoreVersion: "11"
 compatibility:
   minimum: "11"
   verified: "11.315"
-  maximum: "11"
+  maximum: "12"
 authors:
   - name: 'Asacolips'
 esmodules:

--- a/src/yaml/system.yml
+++ b/src/yaml/system.yml
@@ -1,12 +1,12 @@
 name: dungeonworld
 title: Dungeon World
 description: The Dungeon World system for FoundryVTT!
-version: "1.7.1"
+version: "1.7.2"
 minimumCoreVersion: "11"
 compatibleCoreVersion: "11"
 compatibility:
   minimum: "11"
-  verified: "11.309"
+  verified: "11.315"
   maximum: "11"
 authors:
   - name: 'Asacolips'
@@ -254,6 +254,6 @@ initiative: 1d20
 socket: true
 url: https://gitlab.com/asacolips-projects/foundry-mods/dungeonworld
 manifest: https://asacolips-artifacts.s3.amazonaws.com/dungeonworld/master/system.json
-download: https://asacolips-artifacts.s3.amazonaws.com/dungeonworld/1.7.1/dungeonworld.zip
+download: https://asacolips-artifacts.s3.amazonaws.com/dungeonworld/1.7.2/dungeonworld.zip
 changelog: https://gitlab.com/asacolips-projects/foundry-mods/dungeonworld/-/raw/master/CHANGELOG.md
 bugs: https://gitlab.com/asacolips-projects/foundry-mods/dungeonworld/-/issues


### PR DESCRIPTION
## Downloads

Manifest URL: https://asacolips-artifacts.s3.amazonaws.com/dungeonworld/1.7.2/system.json

## Compatible Foundry Versions
![Foundry v11.315](https://img.shields.io/badge/Foundry-v11.315-green)

## Changes

- Updated compendium build script to use the fvtt cli. This allows us to compile directly to LevelDB for Foundry v11, rather than the older NeDB setup that had to be converted when a world was loaded.
- We moved to Github! This shouldn't affect your games directly, but the code repository is now on Github rather than Gitlab. All issues have been migrated to the new repository, and the main reason for the migration was the increased quota of build minutes on Github allowing me to integrate more tests into our pull request and release processes.

## Bug Fixes

- Fixed several bugs related to text editors and displaying their content as enriched. There's still some work left to do on this related to the level up dialog and compendium entries in journals, but character and item sheets should now all display links and rolls properly!


