### PR TITLE
Update actions cache and trigger

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -1,6 +1,6 @@
 name: PR Checks
 on:
-  pull_request_target:
+  pull_request:
 
 concurrency:
   group: "${{ github.ref }}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -101,7 +101,8 @@ jobs:
       uses: actions/cache@v4
       with:
         path: node_modules/
-        key: default
+        key: node-${{ hashFiles('package-lock.json') }}
+        restore-keys: node-
 
     - name: Install NPM dependencies
       run: npm install

--- a/.github/workflows/shared-build.yml
+++ b/.github/workflows/shared-build.yml
@@ -33,7 +33,8 @@ jobs:
       uses: actions/cache@v4
       with:
         path: node_modules/
-        key: default
+        key: node-${{ hashFiles('package-lock.json') }}
+        restore-keys: node-
 
     - name: Install NPM dependencies
       run: npm install


### PR DESCRIPTION
- Updated PR checks action to use `pull_request` instead of `pull_request_target`
- Updated actions to cache node_modules using a hash of the package lock as their cache key