### PR TITLE
Release 1.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# 1.8.0
+
+Release notes: https://github.com/asacolips-projects/dungeonworld/releases/tag/1.8.0
+
+- Added Foundry v12 support
+- Removed Foundry v11 support
+
 # 1.7.2
 
 Release notes: https://github.com/asacolips-projects/dungeonworld/releases/tag/1.7.2

--- a/release-notes/1.8.0.md
+++ b/release-notes/1.8.0.md
@@ -1,0 +1,13 @@
+## Downloads
+
+Manifest URL: https://asacolips-artifacts.s3.amazonaws.com/dungeonworld/1.8.0/system.json
+
+## Compatible Foundry Versions
+![Foundry v12.328](https://img.shields.io/badge/Foundry-v12.328-green)
+
+## Changes
+
+- Added support for Foundry v12 and removed support for Foundry v11.
+
+
+

--- a/src/yaml/system.yml
+++ b/src/yaml/system.yml
@@ -1,13 +1,14 @@
 name: dungeonworld
 title: Dungeon World
 description: The Dungeon World system for FoundryVTT!
-version: "1.7.2"
+version: "1.8.0"
 compatibility:
   minimum: "12"
   verified: "12.328"
   maximum: "12"
 authors:
   - name: 'Asacolips'
+    discord: 'asacolips'
 esmodules:
   - module/dungeonworld.js
 styles:
@@ -252,6 +253,6 @@ initiative: 1d20
 socket: true
 url: https://gitlab.com/asacolips-projects/foundry-mods/dungeonworld
 manifest: https://asacolips-artifacts.s3.amazonaws.com/dungeonworld/latest/system.json
-download: https://asacolips-artifacts.s3.amazonaws.com/dungeonworld/1.7.2/dungeonworld.zip
+download: https://asacolips-artifacts.s3.amazonaws.com/dungeonworld/1.8.0/dungeonworld.zip
 changelog: https://github.com/asacolips-projects/dungeonworld/blob/main/CHANGELOG.md
 bugs: https://github.com/asacolips-projects/dungeonworld/issues


### PR DESCRIPTION
## Downloads

Manifest URL: https://asacolips-artifacts.s3.amazonaws.com/dungeonworld/1.8.0/system.json

## Compatible Foundry Versions
![Foundry v12.328](https://img.shields.io/badge/Foundry-v12.328-green)

## Changes

- Added support for Foundry v12 and removed support for Foundry v11.
