### PR TITLE
Bug fix for scrolling text on Foundry v12

### DIFF
--- a/release-notes/1.8.1.md
+++ b/release-notes/1.8.1.md
@@ -1,0 +1,11 @@
+## Downloads
+
+Manifest URL: https://asacolips-artifacts.s3.amazonaws.com/dungeonworld/1.8.1/system.json
+
+## Compatible Foundry Versions
+![Foundry v12.331](https://img.shields.io/badge/Foundry-v12.331-green)
+
+## Changes
+
+- Fixed an issue where scrolling text for HP updates wouldn't appear on Foundry v12 (@asacolips and @Lifthraser)
+- Updated the Swedish translation (@Rangertheman)

--- a/src/module/actor/actor.js
+++ b/src/module/actor/actor.js
@@ -374,7 +374,7 @@ export class ActorDw extends Actor {
       }
 
       for ( let token of tokens ) {
-        const pct = delta !== 0 ? Math.clamped(Math.abs(delta) / max, 0, 1) : 0.25;
+        const pct = delta !== 0 ? Math.clamp(Math.abs(delta) / max, 0, 1) : 0.25;
         let content = delta !== 0 ? delta.signedString() + " " + suffix : suffix;
         let textOptions = {
           anchor: CONST.TEXT_ANCHOR_POINTS.CENTER,
@@ -394,8 +394,9 @@ export class ActorDw extends Actor {
   /** @override */
   async _preUpdate(data, options, userId) {
     await super._preUpdate(data, options, userId);
+    options.dw = options?.dw ?? {};
 
-    if (options?.dw) {
+    if (!options.dw?.preUpdate) {
       options.dw.preUpdate = {system: foundry.utils.duplicate(this.system)};
     }
   }

--- a/src/yaml/system.yml
+++ b/src/yaml/system.yml
@@ -1,10 +1,10 @@
 name: dungeonworld
 title: Dungeon World
 description: The Dungeon World system for FoundryVTT!
-version: "1.8.0"
+version: "1.8.1"
 compatibility:
   minimum: "12"
-  verified: "12.328"
+  verified: "12.331"
   maximum: "12"
 authors:
   - name: 'Asacolips'
@@ -253,6 +253,6 @@ initiative: 1d20
 socket: true
 url: https://gitlab.com/asacolips-projects/foundry-mods/dungeonworld
 manifest: https://asacolips-artifacts.s3.amazonaws.com/dungeonworld/latest/system.json
-download: https://asacolips-artifacts.s3.amazonaws.com/dungeonworld/1.8.0/dungeonworld.zip
+download: https://asacolips-artifacts.s3.amazonaws.com/dungeonworld/1.8.1/dungeonworld.zip
 changelog: https://github.com/asacolips-projects/dungeonworld/blob/main/CHANGELOG.md
 bugs: https://github.com/asacolips-projects/dungeonworld/issues


### PR DESCRIPTION
- Fixed an issue where scrolling text for HP updates wouldn't appear on Foundry v12.
- Added release notes for 1.8.1